### PR TITLE
Synthetic Generator Improvements

### DIFF
--- a/Deployment.yaml
+++ b/Deployment.yaml
@@ -18,7 +18,8 @@ spec:
             name: trace-load-config
       containers:
       - name: trace-load-generator
-        image: docker.io/omnition/synthetic-load-generator:latest
+        image: us.gcr.io/mvp-demo-301906/kfuse/synthetic-load-generator:latest
+        imagePullPolicy: Always
         env:
           - name: HOST_IP
             valueFrom:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MAVEN=mvn
-DOCKER_IMAGE?=omnition/synthetic-load-generator
+DOCKER_IMAGE?=us.gcr.io/mvp-demo-301906/kfuse/synthetic-load-generator
 BUILD_NUMBER?=latest
 
 .PHONY: all build publish
@@ -16,5 +16,6 @@ java-jars: # Create jars without running tests.
 .PHONY: docker-build
 docker-build:
 	@echo "\n===== $@ ======"
-	envsubst < Dockerfile | docker build --pull -t ${DOCKER_IMAGE}:${BUILD_NUMBER} -f - .
+	envsubst < Dockerfile | docker build --platform linux/amd64 --pull -t ${DOCKER_IMAGE}:${BUILD_NUMBER} -f - .
+	docker push ${DOCKER_IMAGE}:${BUILD_NUMBER}
 

--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceRoute.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceRoute.java
@@ -10,4 +10,5 @@ public class ServiceRoute {
     public Map<String, String> downstreamCalls = new HashMap<>();
     public List<TagSet> tagSets = new ArrayList<>();
     public int maxLatencyMillis;
+    public int minLatencyMillis;
 }

--- a/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
+++ b/src/main/java/io/omnition/loadgenerator/model/topology/ServiceTier.java
@@ -1,8 +1,10 @@
 package io.omnition.loadgenerator.model.topology;
 
+import io.omnition.loadgenerator.model.trace.KeyValue;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -10,9 +12,11 @@ import java.util.concurrent.ConcurrentMap;
 
 public class ServiceTier {
     public String serviceName;
+    public String serviceType;
     public List<TagSet> tagSets = new ArrayList<>();
     public List<ServiceRoute> routes = new ArrayList<>();
     public List<String> instances = new ArrayList<>();
+    public Map<String, String> serviceLabels = new HashMap<>();
 
     private ConcurrentMap<String, TreeMap<Integer, TagSet>> mergedTagSets = new ConcurrentHashMap<>();
     private Random random = new Random();
@@ -21,6 +25,14 @@ public class ServiceTier {
         return this.routes.stream()
                 .filter(r -> r.route.equalsIgnoreCase(routeName))
                 .findFirst().get();
+    }
+
+    public List<KeyValue> getServiceLabels() {
+        List<KeyValue> labels = new ArrayList<>();
+        for(String label : serviceLabels.keySet()) {
+            labels.add(KeyValue.ofStringType(label, serviceLabels.get(label)));
+        }
+        return labels;
     }
 
     public TagSet getTagSet(String routeName) {

--- a/src/main/java/io/omnition/loadgenerator/util/ScheduledTraceGenerator.java
+++ b/src/main/java/io/omnition/loadgenerator/util/ScheduledTraceGenerator.java
@@ -1,5 +1,6 @@
 package io.omnition.loadgenerator.util;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -80,8 +81,9 @@ public class ScheduledTraceGenerator {
             String traceId = this.emitter.emit(trace);
 
             if (this.logLevel == LogLevel.Verbose) {
-                logger.info(String.format("Emitted traceId %s for service %s route %s",
-                    traceId, this.service, this.route));
+                logger.info(String.format("Emitted traceId %s for service %s route %s start time %s end time %s",
+                        traceId, this.service, this.route, new Timestamp(TimeUnit.MICROSECONDS.toMillis(trace.rootSpan.startTimeMicros)),
+                        new Timestamp(TimeUnit.MICROSECONDS.toMillis(trace.rootSpan.endTimeMicros))));
             }
             if (this.logLevel != LogLevel.Silent) {
                 this.summaryLogger.logEmit(1, trace.spans.size());

--- a/topologies/6-22-stag-db-labels-1.json
+++ b/topologies/6-22-stag-db-labels-1.json
@@ -1,0 +1,5963 @@
+{
+  "topology": {
+    "services": [
+      {
+        "serviceName": "service-0",
+        "instances": [
+          "service-0-instance-0",
+          "service-0-instance-1",
+          "service-0-instance-2",
+          "service-0-instance-3",
+          "service-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "route-0",
+            "downstreamCalls": {
+              "service-1-0": "service-1-0-route-0",
+              "service-1-1": "service-1-1-route-0",
+              "service-1-2": "service-1-2-route-0",
+              "service-1-3": "service-1-3-route-0",
+              "service-1-4": "service-1-4-route-0",
+              "service-1-5": "service-1-5-route-0",
+              "service-1-6": "service-1-6-route-0",
+              "service-1-7": "HGET",
+              "service-1-8": "service-1-8-route-0",
+              "service-1-9": "service-1-9-route-0"
+            },
+            "maxLatencyMillis": 12,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-1",
+            "downstreamCalls": {
+              "service-1-0": "service-1-0-route-1",
+              "service-1-1": "service-1-1-route-1",
+              "service-1-2": "service-1-2-route-1",
+              "service-1-3": "service-1-3-route-1",
+              "service-1-4": "service-1-4-route-1",
+              "service-1-5": "service-1-5-route-1",
+              "service-1-6": "service-1-6-route-1",
+              "service-1-7": "HGETALL",
+              "service-1-8": "service-1-8-route-1",
+              "service-1-9": "service-1-9-route-1"
+            },
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-2",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-3",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 57,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-4",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 94,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-5",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 63,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-6",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 46,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-7",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 22,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-8",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-9",
+            "downstreamCalls": {
+              "service-9-0": "service-9-0-route-0",
+              "service-9-1": "service-9-1-route-0"
+            },
+            "maxLatencyMillis": 34,
+            "minLatencyMillis": 60000,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-0",
+        "instances": [
+          "service-1-0-instance-0",
+          "service-1-0-instance-1",
+          "service-1-0-instance-2",
+          "service-1-0-instance-3",
+          "service-1-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-0-route-0",
+            "downstreamCalls": {
+              "service-2-0": "service-2-0-route-0",
+              "service-2-1": "service-2-1-route-0",
+              "service-2-2": "service-2-2-route-0",
+              "service-2-3": "service-2-3-route-0",
+              "service-2-4": "service-2-4-route-0",
+              "service-2-5": "postgres.query",
+              "service-2-6": "service-2-6-route-0",
+              "service-2-7": "service-2-7-route-0",
+              "service-2-8": "service-2-8-route-0",
+              "service-2-9": "service-2-9-route-0"
+            },
+            "maxLatencyMillis": 77,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-0-route-1",
+            "downstreamCalls": {
+              "service-2-0": "service-2-0-route-1",
+              "service-2-1": "service-2-1-route-1",
+              "service-2-2": "service-2-2-route-1",
+              "service-2-3": "service-2-3-route-1",
+              "service-2-4": "service-2-4-route-1",
+              "service-2-5": "postgres.query",
+              "service-2-6": "service-2-6-route-1",
+              "service-2-7": "service-2-7-route-1",
+              "service-2-8": "service-2-8-route-1",
+              "service-2-9": "service-2-9-route-1"
+            },
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-1",
+        "instances": [
+          "service-1-1-instance-0",
+          "service-1-1-instance-1",
+          "service-1-1-instance-2",
+          "service-1-1-instance-3",
+          "service-1-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 88,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-2",
+        "instances": [
+          "service-1-2-instance-0",
+          "service-1-2-instance-1",
+          "service-1-2-instance-2",
+          "service-1-2-instance-3",
+          "service-1-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 43,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 50,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-3",
+        "instances": [
+          "service-1-3-instance-0",
+          "service-1-3-instance-1",
+          "service-1-3-instance-2",
+          "service-1-3-instance-3",
+          "service-1-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 24,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 26,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-4",
+        "instances": [
+          "service-1-4-instance-0",
+          "service-1-4-instance-1",
+          "service-1-4-instance-2",
+          "service-1-4-instance-3",
+          "service-1-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 40,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 94,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-5",
+        "instances": [
+          "service-1-5-instance-0",
+          "service-1-5-instance-1",
+          "service-1-5-instance-2",
+          "service-1-5-instance-3",
+          "service-1-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 29,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-6",
+        "instances": [
+          "service-1-6-instance-0",
+          "service-1-6-instance-1",
+          "service-1-6-instance-2",
+          "service-1-6-instance-3",
+          "service-1-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 30,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 31,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-7",
+        "instances": [
+          "service-1-7-instance-0",
+          "service-1-7-instance-1",
+          "service-1-7-instance-2",
+          "service-1-7-instance-3",
+          "service-1-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "HGET",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "HGETALL",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-1-8",
+        "instances": [
+          "service-1-8-instance-0",
+          "service-1-8-instance-1",
+          "service-1-8-instance-2",
+          "service-1-8-instance-3",
+          "service-1-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 72,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-9",
+        "instances": [
+          "service-1-9-instance-0",
+          "service-1-9-instance-1",
+          "service-1-9-instance-2",
+          "service-1-9-instance-3",
+          "service-1-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-0",
+        "instances": [
+          "service-2-0-instance-0",
+          "service-2-0-instance-1",
+          "service-2-0-instance-2",
+          "service-2-0-instance-3",
+          "service-2-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-0-route-0",
+            "downstreamCalls": {
+              "service-3-0": "service-3-0-route-0",
+              "service-3-1": "service-3-1-route-0",
+              "service-3-2": "service-3-2-route-0",
+              "service-3-3": "service-3-3-route-0",
+              "service-3-4": "HGETALL",
+              "service-3-5": "service-3-5-route-0",
+              "service-3-6": "service-3-6-route-0",
+              "service-3-7": "service-3-7-route-0",
+              "service-3-8": "service-3-8-route-0",
+              "service-3-9": "service-3-9-route-0"
+            },
+            "maxLatencyMillis": 26,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-0-route-1",
+            "downstreamCalls": {
+              "service-3-0": "service-3-0-route-1",
+              "service-3-1": "service-3-1-route-1",
+              "service-3-2": "service-3-2-route-1",
+              "service-3-3": "service-3-3-route-1",
+              "service-3-4": "HGET",
+              "service-3-5": "service-3-5-route-1",
+              "service-3-6": "service-3-6-route-1",
+              "service-3-7": "service-3-7-route-1",
+              "service-3-8": "service-3-8-route-1",
+              "service-3-9": "service-3-9-route-1"
+            },
+            "maxLatencyMillis": 35,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-1",
+        "instances": [
+          "service-2-1-instance-0",
+          "service-2-1-instance-1",
+          "service-2-1-instance-2",
+          "service-2-1-instance-3",
+          "service-2-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 58,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-2",
+        "instances": [
+          "service-2-2-instance-0",
+          "service-2-2-instance-1",
+          "service-2-2-instance-2",
+          "service-2-2-instance-3",
+          "service-2-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 38,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-3",
+        "instances": [
+          "service-2-3-instance-0",
+          "service-2-3-instance-1",
+          "service-2-3-instance-2",
+          "service-2-3-instance-3",
+          "service-2-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 47,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-4",
+        "instances": [
+          "service-2-4-instance-0",
+          "service-2-4-instance-1",
+          "service-2-4-instance-2",
+          "service-2-4-instance-3",
+          "service-2-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 97,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-5",
+        "instances": [
+          "service-2-5-instance-0",
+          "service-2-5-instance-1",
+          "service-2-5-instance-2",
+          "service-2-5-instance-3",
+          "service-2-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "postgres.query",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 40,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "postgres",
+                  "db.system": "postgresql",
+                  "db.user": "postgres",
+                  "network.peer.address": "test-db"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-2-6",
+        "instances": [
+          "service-2-6-instance-0",
+          "service-2-6-instance-1",
+          "service-2-6-instance-2",
+          "service-2-6-instance-3",
+          "service-2-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 35,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 58,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-7",
+        "instances": [
+          "service-2-7-instance-0",
+          "service-2-7-instance-1",
+          "service-2-7-instance-2",
+          "service-2-7-instance-3",
+          "service-2-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 45,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 78,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-8",
+        "instances": [
+          "service-2-8-instance-0",
+          "service-2-8-instance-1",
+          "service-2-8-instance-2",
+          "service-2-8-instance-3",
+          "service-2-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 23,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 36,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-9",
+        "instances": [
+          "service-2-9-instance-0",
+          "service-2-9-instance-1",
+          "service-2-9-instance-2",
+          "service-2-9-instance-3",
+          "service-2-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 42,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 99,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-0",
+        "instances": [
+          "service-3-0-instance-0",
+          "service-3-0-instance-1",
+          "service-3-0-instance-2",
+          "service-3-0-instance-3",
+          "service-3-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-0-route-0",
+            "downstreamCalls": {
+              "service-4-0": "service-4-0-route-0",
+              "service-4-1": "postgres.query",
+              "service-4-2": "service-4-2-route-0",
+              "service-4-3": "service-4-3-route-0",
+              "service-4-4": "service-4-4-route-0",
+              "service-4-5": "service-4-5-route-0",
+              "service-4-6": "service-4-6-route-0",
+              "service-4-7": "service-4-7-route-0",
+              "service-4-8": "service-4-8-route-0",
+              "service-4-9": "service-4-9-route-0"
+            },
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-0-route-1",
+            "downstreamCalls": {
+              "service-4-0": "service-4-0-route-1",
+              "service-4-1": "postgres.query",
+              "service-4-2": "service-4-2-route-1",
+              "service-4-3": "service-4-3-route-1",
+              "service-4-4": "service-4-4-route-1",
+              "service-4-5": "service-4-5-route-1",
+              "service-4-6": "service-4-6-route-1",
+              "service-4-7": "service-4-7-route-1",
+              "service-4-8": "service-4-8-route-1",
+              "service-4-9": "service-4-9-route-1"
+            },
+            "maxLatencyMillis": 96,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-1",
+        "instances": [
+          "service-3-1-instance-0",
+          "service-3-1-instance-1",
+          "service-3-1-instance-2",
+          "service-3-1-instance-3",
+          "service-3-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 19,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 18,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-2",
+        "instances": [
+          "service-3-2-instance-0",
+          "service-3-2-instance-1",
+          "service-3-2-instance-2",
+          "service-3-2-instance-3",
+          "service-3-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 48,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-3",
+        "instances": [
+          "service-3-3-instance-0",
+          "service-3-3-instance-1",
+          "service-3-3-instance-2",
+          "service-3-3-instance-3",
+          "service-3-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 46,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-4",
+        "instances": [
+          "service-3-4-instance-0",
+          "service-3-4-instance-1",
+          "service-3-4-instance-2",
+          "service-3-4-instance-3",
+          "service-3-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "HGET",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "HGETALL",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 79,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-3-5",
+        "instances": [
+          "service-3-5-instance-0",
+          "service-3-5-instance-1",
+          "service-3-5-instance-2",
+          "service-3-5-instance-3",
+          "service-3-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 70,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 61,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-6",
+        "instances": [
+          "service-3-6-instance-0",
+          "service-3-6-instance-1",
+          "service-3-6-instance-2",
+          "service-3-6-instance-3",
+          "service-3-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 13,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 23,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-7",
+        "instances": [
+          "service-3-7-instance-0",
+          "service-3-7-instance-1",
+          "service-3-7-instance-2",
+          "service-3-7-instance-3",
+          "service-3-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 13,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 68,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-8",
+        "instances": [
+          "service-3-8-instance-0",
+          "service-3-8-instance-1",
+          "service-3-8-instance-2",
+          "service-3-8-instance-3",
+          "service-3-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 67,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-9",
+        "instances": [
+          "service-3-9-instance-0",
+          "service-3-9-instance-1",
+          "service-3-9-instance-2",
+          "service-3-9-instance-3",
+          "service-3-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 78,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 86,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-0",
+        "instances": [
+          "service-4-0-instance-0",
+          "service-4-0-instance-1",
+          "service-4-0-instance-2",
+          "service-4-0-instance-3",
+          "service-4-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-0-route-0",
+            "downstreamCalls": {
+              "service-5-0": "service-5-0-route-0",
+              "service-5-1": "service-5-1-route-0",
+              "service-5-2": "service-5-2-route-0",
+              "service-5-3": "service-5-3-route-0",
+              "service-5-4": "service-5-4-route-0",
+              "service-5-5": "service-5-5-route-0",
+              "service-5-6": "service-5-6-route-0",
+              "service-5-7": "service-5-7-route-0",
+              "service-5-8": "service-5-8-route-0",
+              "service-5-9": "service-5-9-route-0"
+            },
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-0-route-1",
+            "downstreamCalls": {
+              "service-5-0": "service-5-0-route-1",
+              "service-5-1": "service-5-1-route-1",
+              "service-5-2": "service-5-2-route-1",
+              "service-5-3": "service-5-3-route-1",
+              "service-5-4": "service-5-4-route-1",
+              "service-5-5": "service-5-5-route-1",
+              "service-5-6": "service-5-6-route-1",
+              "service-5-7": "service-5-7-route-1",
+              "service-5-8": "service-5-8-route-1",
+              "service-5-9": "service-5-9-route-1"
+            },
+            "maxLatencyMillis": 77,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-1",
+        "instances": [
+          "service-4-1-instance-0",
+          "service-4-1-instance-1",
+          "service-4-1-instance-2",
+          "service-4-1-instance-3",
+          "service-4-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "postgres.query",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "postgres",
+                  "db.system": "postgresql",
+                  "db.user": "postgres",
+                  "network.peer.address": "stag-db"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-4-2",
+        "instances": [
+          "service-4-2-instance-0",
+          "service-4-2-instance-1",
+          "service-4-2-instance-2",
+          "service-4-2-instance-3",
+          "service-4-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 29,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 56,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-3",
+        "instances": [
+          "service-4-3-instance-0",
+          "service-4-3-instance-1",
+          "service-4-3-instance-2",
+          "service-4-3-instance-3",
+          "service-4-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 94,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-4",
+        "instances": [
+          "service-4-4-instance-0",
+          "service-4-4-instance-1",
+          "service-4-4-instance-2",
+          "service-4-4-instance-3",
+          "service-4-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 47,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-5",
+        "instances": [
+          "service-4-5-instance-0",
+          "service-4-5-instance-1",
+          "service-4-5-instance-2",
+          "service-4-5-instance-3",
+          "service-4-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 82,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-6",
+        "instances": [
+          "service-4-6-instance-0",
+          "service-4-6-instance-1",
+          "service-4-6-instance-2",
+          "service-4-6-instance-3",
+          "service-4-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 41,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 33,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-7",
+        "instances": [
+          "service-4-7-instance-0",
+          "service-4-7-instance-1",
+          "service-4-7-instance-2",
+          "service-4-7-instance-3",
+          "service-4-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 46,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 83,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-8",
+        "instances": [
+          "service-4-8-instance-0",
+          "service-4-8-instance-1",
+          "service-4-8-instance-2",
+          "service-4-8-instance-3",
+          "service-4-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 27,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 69,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-9",
+        "instances": [
+          "service-4-9-instance-0",
+          "service-4-9-instance-1",
+          "service-4-9-instance-2",
+          "service-4-9-instance-3",
+          "service-4-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 16,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-0",
+        "instances": [
+          "service-5-0-instance-0",
+          "service-5-0-instance-1",
+          "service-5-0-instance-2",
+          "service-5-0-instance-3",
+          "service-5-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-0-route-0",
+            "downstreamCalls": {
+              "service-6-0": "service-6-0-route-0",
+              "service-6-1": "service-6-1-route-0",
+              "service-6-2": "service-6-2-route-0",
+              "service-6-3": "service-6-3-route-0",
+              "service-6-4": "service-6-4-route-0",
+              "service-6-5": "service-6-5-route-0",
+              "service-6-6": "service-6-6-route-0",
+              "service-6-7": "service-6-7-route-0",
+              "service-6-8": "service-6-8-route-0",
+              "service-6-9": "service-6-9-route-0"
+            },
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-0-route-1",
+            "downstreamCalls": {
+              "service-6-0": "service-6-0-route-1",
+              "service-6-1": "service-6-1-route-1",
+              "service-6-2": "service-6-2-route-1",
+              "service-6-3": "service-6-3-route-1",
+              "service-6-4": "service-6-4-route-1",
+              "service-6-5": "service-6-5-route-1",
+              "service-6-6": "service-6-6-route-1",
+              "service-6-7": "service-6-7-route-1",
+              "service-6-8": "service-6-8-route-1",
+              "service-6-9": "service-6-9-route-1"
+            },
+            "maxLatencyMillis": 59,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-1",
+        "instances": [
+          "service-5-1-instance-0",
+          "service-5-1-instance-1",
+          "service-5-1-instance-2",
+          "service-5-1-instance-3",
+          "service-5-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 61,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 20,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-2",
+        "instances": [
+          "service-5-2-instance-0",
+          "service-5-2-instance-1",
+          "service-5-2-instance-2",
+          "service-5-2-instance-3",
+          "service-5-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 36,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 19,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-3",
+        "instances": [
+          "service-5-3-instance-0",
+          "service-5-3-instance-1",
+          "service-5-3-instance-2",
+          "service-5-3-instance-3",
+          "service-5-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 14,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 33,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "external"
+      },
+      {
+        "serviceName": "service-5-4",
+        "instances": [
+          "service-5-4-instance-0",
+          "service-5-4-instance-1",
+          "service-5-4-instance-2",
+          "service-5-4-instance-3",
+          "service-5-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 75,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-5",
+        "instances": [
+          "service-5-5-instance-0",
+          "service-5-5-instance-1",
+          "service-5-5-instance-2",
+          "service-5-5-instance-3",
+          "service-5-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 58,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 28,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-6",
+        "instances": [
+          "service-5-6-instance-0",
+          "service-5-6-instance-1",
+          "service-5-6-instance-2",
+          "service-5-6-instance-3",
+          "service-5-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-7",
+        "instances": [
+          "service-5-7-instance-0",
+          "service-5-7-instance-1",
+          "service-5-7-instance-2",
+          "service-5-7-instance-3",
+          "service-5-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 36,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 28,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-8",
+        "instances": [
+          "service-5-8-instance-0",
+          "service-5-8-instance-1",
+          "service-5-8-instance-2",
+          "service-5-8-instance-3",
+          "service-5-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 97,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 99,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-9",
+        "instances": [
+          "service-5-9-instance-0",
+          "service-5-9-instance-1",
+          "service-5-9-instance-2",
+          "service-5-9-instance-3",
+          "service-5-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 55,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 40,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west2-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-west2"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-0",
+        "instances": [
+          "service-6-0-instance-0",
+          "service-6-0-instance-1",
+          "service-6-0-instance-2",
+          "service-6-0-instance-3",
+          "service-6-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-0-route-0",
+            "downstreamCalls": {
+              "service-7-0": "service-7-0-route-0",
+              "service-7-1": "service-7-1-route-0",
+              "service-7-2": "service-7-2-route-0",
+              "service-7-3": "service-7-3-route-0",
+              "service-7-4": "service-7-4-route-0",
+              "service-7-5": "service-7-5-route-0",
+              "service-7-6": "service-7-6-route-0",
+              "service-7-7": "service-7-7-route-0",
+              "service-7-8": "service-7-8-route-0",
+              "service-7-9": "service-7-9-route-0"
+            },
+            "maxLatencyMillis": 45,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-0-route-1",
+            "downstreamCalls": {
+              "service-7-0": "service-7-0-route-1",
+              "service-7-1": "service-7-1-route-1",
+              "service-7-2": "service-7-2-route-1",
+              "service-7-3": "service-7-3-route-1",
+              "service-7-4": "service-7-4-route-1",
+              "service-7-5": "service-7-5-route-1",
+              "service-7-6": "service-7-6-route-1",
+              "service-7-7": "service-7-7-route-1",
+              "service-7-8": "service-7-8-route-1",
+              "service-7-9": "service-7-9-route-1"
+            },
+            "maxLatencyMillis": 17,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-1",
+        "instances": [
+          "service-6-1-instance-0",
+          "service-6-1-instance-1",
+          "service-6-1-instance-2",
+          "service-6-1-instance-3",
+          "service-6-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 32,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 65,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-2",
+        "instances": [
+          "service-6-2-instance-0",
+          "service-6-2-instance-1",
+          "service-6-2-instance-2",
+          "service-6-2-instance-3",
+          "service-6-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 98,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-3",
+        "instances": [
+          "service-6-3-instance-0",
+          "service-6-3-instance-1",
+          "service-6-3-instance-2",
+          "service-6-3-instance-3",
+          "service-6-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 47,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-4",
+        "instances": [
+          "service-6-4-instance-0",
+          "service-6-4-instance-1",
+          "service-6-4-instance-2",
+          "service-6-4-instance-3",
+          "service-6-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 53,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-5",
+        "instances": [
+          "service-6-5-instance-0",
+          "service-6-5-instance-1",
+          "service-6-5-instance-2",
+          "service-6-5-instance-3",
+          "service-6-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 67,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 78,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-6",
+        "instances": [
+          "service-6-6-instance-0",
+          "service-6-6-instance-1",
+          "service-6-6-instance-2",
+          "service-6-6-instance-3",
+          "service-6-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 66,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-7",
+        "instances": [
+          "service-6-7-instance-0",
+          "service-6-7-instance-1",
+          "service-6-7-instance-2",
+          "service-6-7-instance-3",
+          "service-6-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 29,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 18,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-8",
+        "instances": [
+          "service-6-8-instance-0",
+          "service-6-8-instance-1",
+          "service-6-8-instance-2",
+          "service-6-8-instance-3",
+          "service-6-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 52,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-9",
+        "instances": [
+          "service-6-9-instance-0",
+          "service-6-9-instance-1",
+          "service-6-9-instance-2",
+          "service-6-9-instance-3",
+          "service-6-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 63,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 49,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-0",
+        "instances": [
+          "service-7-0-instance-0",
+          "service-7-0-instance-1",
+          "service-7-0-instance-2",
+          "service-7-0-instance-3",
+          "service-7-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-0-route-0",
+            "downstreamCalls": {
+              "service-8-0": "service-8-0-route-0",
+              "service-8-1": "service-8-1-route-0",
+              "service-8-2": "service-8-2-route-0",
+              "service-8-3": "service-8-3-route-0",
+              "service-8-4": "service-8-4-route-0",
+              "service-8-5": "service-8-5-route-0",
+              "service-8-6": "service-8-6-route-0",
+              "service-8-7": "service-8-7-route-0",
+              "service-8-8": "service-8-8-route-0",
+              "service-8-9": "service-8-9-route-0"
+            },
+            "maxLatencyMillis": 37,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-0-route-1",
+            "downstreamCalls": {
+              "service-8-0": "service-8-0-route-1",
+              "service-8-1": "service-8-1-route-1",
+              "service-8-2": "service-8-2-route-1",
+              "service-8-3": "service-8-3-route-1",
+              "service-8-4": "service-8-4-route-1",
+              "service-8-5": "service-8-5-route-1",
+              "service-8-6": "service-8-6-route-1",
+              "service-8-7": "service-8-7-route-1",
+              "service-8-8": "service-8-8-route-1",
+              "service-8-9": "service-8-9-route-1"
+            },
+            "maxLatencyMillis": 91,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-1",
+        "instances": [
+          "service-7-1-instance-0",
+          "service-7-1-instance-1",
+          "service-7-1-instance-2",
+          "service-7-1-instance-3",
+          "service-7-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 86,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 39,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-2",
+        "instances": [
+          "service-7-2-instance-0",
+          "service-7-2-instance-1",
+          "service-7-2-instance-2",
+          "service-7-2-instance-3",
+          "service-7-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 79,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 96,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "external"
+      },
+      {
+        "serviceName": "service-7-3",
+        "instances": [
+          "service-7-3-instance-0",
+          "service-7-3-instance-1",
+          "service-7-3-instance-2",
+          "service-7-3-instance-3",
+          "service-7-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 35,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 59,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-4",
+        "instances": [
+          "service-7-4-instance-0",
+          "service-7-4-instance-1",
+          "service-7-4-instance-2",
+          "service-7-4-instance-3",
+          "service-7-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 14,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 11,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-5",
+        "instances": [
+          "service-7-5-instance-0",
+          "service-7-5-instance-1",
+          "service-7-5-instance-2",
+          "service-7-5-instance-3",
+          "service-7-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 43,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-6",
+        "instances": [
+          "service-7-6-instance-0",
+          "service-7-6-instance-1",
+          "service-7-6-instance-2",
+          "service-7-6-instance-3",
+          "service-7-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 55,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 85,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-7",
+        "instances": [
+          "service-7-7-instance-0",
+          "service-7-7-instance-1",
+          "service-7-7-instance-2",
+          "service-7-7-instance-3",
+          "service-7-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 13,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 89,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-8",
+        "instances": [
+          "service-7-8-instance-0",
+          "service-7-8-instance-1",
+          "service-7-8-instance-2",
+          "service-7-8-instance-3",
+          "service-7-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-9",
+        "instances": [
+          "service-7-9-instance-0",
+          "service-7-9-instance-1",
+          "service-7-9-instance-2",
+          "service-7-9-instance-3",
+          "service-7-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 44,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-8-0",
+        "instances": [
+          "service-8-0-instance-0",
+          "service-8-0-instance-1",
+          "service-8-0-instance-2",
+          "service-8-0-instance-3",
+          "service-8-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-0-route-0",
+            "downstreamCalls": {
+              "service-9-0": "service-9-0-route-0",
+              "service-9-1": "service-9-1-route-0",
+              "service-9-2": "service-9-2-route-0",
+              "service-9-3": "service-9-3-route-0",
+              "service-9-4": "service-9-4-route-0",
+              "service-9-5": "service-9-5-route-0",
+              "service-9-6": "service-9-6-route-0",
+              "service-9-7": "service-9-7-route-0",
+              "service-9-8": "service-9-8-route-0",
+              "service-9-9": "service-9-9-route-0"
+            },
+            "maxLatencyMillis": 54,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-0-route-1",
+            "downstreamCalls": {
+              "service-9-0": "service-9-0-route-1",
+              "service-9-1": "service-9-1-route-1",
+              "service-9-2": "service-9-2-route-1",
+              "service-9-3": "service-9-3-route-1",
+              "service-9-4": "service-9-4-route-1",
+              "service-9-5": "service-9-5-route-1",
+              "service-9-6": "service-9-6-route-1",
+              "service-9-7": "service-9-7-route-1",
+              "service-9-8": "service-9-8-route-1",
+              "service-9-9": "service-9-9-route-1"
+            },
+            "maxLatencyMillis": 42,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-1",
+        "instances": [
+          "service-8-1-instance-0",
+          "service-8-1-instance-1",
+          "service-8-1-instance-2",
+          "service-8-1-instance-3",
+          "service-8-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 93,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-2",
+        "instances": [
+          "service-8-2-instance-0",
+          "service-8-2-instance-1",
+          "service-8-2-instance-2",
+          "service-8-2-instance-3",
+          "service-8-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 30,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-3",
+        "instances": [
+          "service-8-3-instance-0",
+          "service-8-3-instance-1",
+          "service-8-3-instance-2",
+          "service-8-3-instance-3",
+          "service-8-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 67,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 18,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-4",
+        "instances": [
+          "service-8-4-instance-0",
+          "service-8-4-instance-1",
+          "service-8-4-instance-2",
+          "service-8-4-instance-3",
+          "service-8-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 56,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-5",
+        "instances": [
+          "service-8-5-instance-0",
+          "service-8-5-instance-1",
+          "service-8-5-instance-2",
+          "service-8-5-instance-3",
+          "service-8-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 86,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 83,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-6",
+        "instances": [
+          "service-8-6-instance-0",
+          "service-8-6-instance-1",
+          "service-8-6-instance-2",
+          "service-8-6-instance-3",
+          "service-8-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 57,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 27,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-7",
+        "instances": [
+          "service-8-7-instance-0",
+          "service-8-7-instance-1",
+          "service-8-7-instance-2",
+          "service-8-7-instance-3",
+          "service-8-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 85,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 24,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-8",
+        "instances": [
+          "service-8-8-instance-0",
+          "service-8-8-instance-1",
+          "service-8-8-instance-2",
+          "service-8-8-instance-3",
+          "service-8-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-9",
+        "instances": [
+          "service-8-9-instance-0",
+          "service-8-9-instance-1",
+          "service-8-9-instance-2",
+          "service-8-9-instance-3",
+          "service-8-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 27,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-gcp",
+          "kube_namespace": "omnition-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-9-0",
+        "instances": [
+          "service-9-0-instance-0",
+          "service-9-0-instance-1",
+          "service-9-0-instance-2",
+          "service-9-0-instance-3",
+          "service-9-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-0-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 71,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-0-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-1",
+        "instances": [
+          "service-9-1-instance-0",
+          "service-9-1-instance-1",
+          "service-9-1-instance-2",
+          "service-9-1-instance-3",
+          "service-9-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-2",
+        "instances": [
+          "service-9-2-instance-0",
+          "service-9-2-instance-1",
+          "service-9-2-instance-2",
+          "service-9-2-instance-3",
+          "service-9-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 26,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 33,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-3",
+        "instances": [
+          "service-9-3-instance-0",
+          "service-9-3-instance-1",
+          "service-9-3-instance-2",
+          "service-9-3-instance-3",
+          "service-9-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 53,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-4",
+        "instances": [
+          "service-9-4-instance-0",
+          "service-9-4-instance-1",
+          "service-9-4-instance-2",
+          "service-9-4-instance-3",
+          "service-9-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 83,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 28,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-5",
+        "instances": [
+          "service-9-5-instance-0",
+          "service-9-5-instance-1",
+          "service-9-5-instance-2",
+          "service-9-5-instance-3",
+          "service-9-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 53,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 89,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-6",
+        "instances": [
+          "service-9-6-instance-0",
+          "service-9-6-instance-1",
+          "service-9-6-instance-2",
+          "service-9-6-instance-3",
+          "service-9-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 52,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-7",
+        "instances": [
+          "service-9-7-instance-0",
+          "service-9-7-instance-1",
+          "service-9-7-instance-2",
+          "service-9-7-instance-3",
+          "service-9-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 12,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-8",
+        "instances": [
+          "service-9-8-instance-0",
+          "service-9-8-instance-1",
+          "service-9-8-instance-2",
+          "service-9-8-instance-3",
+          "service-9-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 97,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 48,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-9",
+        "instances": [
+          "service-9-9-instance-0",
+          "service-9-9-instance-1",
+          "service-9-9-instance-2",
+          "service-9-9-instance-3",
+          "service-9-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 93,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east5-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-shared",
+          "kube_namespace": "synthetic-trace",
+          "region": "us-east5"
+        },
+        "serviceType": "http"
+      }
+    ]
+  },
+  "rootRoutes": [
+    {
+      "service": "service-0",
+      "route": "route-0",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-1",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-2",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-3",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-4",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-5",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-6",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-7",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-8",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-9",
+      "tracesPerHour": 3600
+    }
+  ]
+}

--- a/topologies/6-22-stag-db-labels-2.json
+++ b/topologies/6-22-stag-db-labels-2.json
@@ -1,0 +1,5963 @@
+{
+  "topology": {
+    "services": [
+      {
+        "serviceName": "service-0",
+        "instances": [
+          "service-0-instance-0",
+          "service-0-instance-1",
+          "service-0-instance-2",
+          "service-0-instance-3",
+          "service-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "route-0",
+            "downstreamCalls": {
+              "service-1-0": "service-1-0-route-0",
+              "service-1-1": "service-1-1-route-0",
+              "service-1-2": "service-1-2-route-0",
+              "service-1-3": "service-1-3-route-0",
+              "service-1-4": "service-1-4-route-0",
+              "service-1-5": "service-1-5-route-0",
+              "service-1-6": "service-1-6-route-0",
+              "service-1-7": "HGET",
+              "service-1-8": "service-1-8-route-0",
+              "service-1-9": "service-1-9-route-0"
+            },
+            "maxLatencyMillis": 12,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-1",
+            "downstreamCalls": {
+              "service-1-0": "service-1-0-route-1",
+              "service-1-1": "service-1-1-route-1",
+              "service-1-2": "service-1-2-route-1",
+              "service-1-3": "service-1-3-route-1",
+              "service-1-4": "service-1-4-route-1",
+              "service-1-5": "service-1-5-route-1",
+              "service-1-6": "service-1-6-route-1",
+              "service-1-7": "HGETALL",
+              "service-1-8": "service-1-8-route-1",
+              "service-1-9": "service-1-9-route-1"
+            },
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-2",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-3",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 57,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-4",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 94,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-5",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 63,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-6",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 46,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-7",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 22,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-8",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "route-9",
+            "downstreamCalls": {
+              "service-9-0": "service-9-0-route-0",
+              "service-9-1": "service-9-1-route-0"
+            },
+            "maxLatencyMillis": 34,
+            "minLatencyMillis": 60000,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-0",
+        "instances": [
+          "service-1-0-instance-0",
+          "service-1-0-instance-1",
+          "service-1-0-instance-2",
+          "service-1-0-instance-3",
+          "service-1-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-0-route-0",
+            "downstreamCalls": {
+              "service-2-0": "service-2-0-route-0",
+              "service-2-1": "service-2-1-route-0",
+              "service-2-2": "service-2-2-route-0",
+              "service-2-3": "service-2-3-route-0",
+              "service-2-4": "service-2-4-route-0",
+              "service-2-5": "postgres.query",
+              "service-2-6": "service-2-6-route-0",
+              "service-2-7": "service-2-7-route-0",
+              "service-2-8": "service-2-8-route-0",
+              "service-2-9": "service-2-9-route-0"
+            },
+            "maxLatencyMillis": 77,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-0-route-1",
+            "downstreamCalls": {
+              "service-2-0": "service-2-0-route-1",
+              "service-2-1": "service-2-1-route-1",
+              "service-2-2": "service-2-2-route-1",
+              "service-2-3": "service-2-3-route-1",
+              "service-2-4": "service-2-4-route-1",
+              "service-2-5": "postgres.query",
+              "service-2-6": "service-2-6-route-1",
+              "service-2-7": "service-2-7-route-1",
+              "service-2-8": "service-2-8-route-1",
+              "service-2-9": "service-2-9-route-1"
+            },
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-1",
+        "instances": [
+          "service-1-1-instance-0",
+          "service-1-1-instance-1",
+          "service-1-1-instance-2",
+          "service-1-1-instance-3",
+          "service-1-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 88,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-2",
+        "instances": [
+          "service-1-2-instance-0",
+          "service-1-2-instance-1",
+          "service-1-2-instance-2",
+          "service-1-2-instance-3",
+          "service-1-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 43,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 50,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-3",
+        "instances": [
+          "service-1-3-instance-0",
+          "service-1-3-instance-1",
+          "service-1-3-instance-2",
+          "service-1-3-instance-3",
+          "service-1-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 24,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 26,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-4",
+        "instances": [
+          "service-1-4-instance-0",
+          "service-1-4-instance-1",
+          "service-1-4-instance-2",
+          "service-1-4-instance-3",
+          "service-1-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 40,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 94,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-5",
+        "instances": [
+          "service-1-5-instance-0",
+          "service-1-5-instance-1",
+          "service-1-5-instance-2",
+          "service-1-5-instance-3",
+          "service-1-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 29,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-6",
+        "instances": [
+          "service-1-6-instance-0",
+          "service-1-6-instance-1",
+          "service-1-6-instance-2",
+          "service-1-6-instance-3",
+          "service-1-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 30,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 31,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-7",
+        "instances": [
+          "service-1-7-instance-0",
+          "service-1-7-instance-1",
+          "service-1-7-instance-2",
+          "service-1-7-instance-3",
+          "service-1-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "HGET",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "HGETALL",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-1-8",
+        "instances": [
+          "service-1-8-instance-0",
+          "service-1-8-instance-1",
+          "service-1-8-instance-2",
+          "service-1-8-instance-3",
+          "service-1-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 72,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-1-9",
+        "instances": [
+          "service-1-9-instance-0",
+          "service-1-9-instance-1",
+          "service-1-9-instance-2",
+          "service-1-9-instance-3",
+          "service-1-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-1-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-1-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-0",
+        "instances": [
+          "service-2-0-instance-0",
+          "service-2-0-instance-1",
+          "service-2-0-instance-2",
+          "service-2-0-instance-3",
+          "service-2-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-0-route-0",
+            "downstreamCalls": {
+              "service-3-0": "service-3-0-route-0",
+              "service-3-1": "service-3-1-route-0",
+              "service-3-2": "service-3-2-route-0",
+              "service-3-3": "service-3-3-route-0",
+              "service-3-4": "HGETALL",
+              "service-3-5": "service-3-5-route-0",
+              "service-3-6": "service-3-6-route-0",
+              "service-3-7": "service-3-7-route-0",
+              "service-3-8": "service-3-8-route-0",
+              "service-3-9": "service-3-9-route-0"
+            },
+            "maxLatencyMillis": 26,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-0-route-1",
+            "downstreamCalls": {
+              "service-3-0": "service-3-0-route-1",
+              "service-3-1": "service-3-1-route-1",
+              "service-3-2": "service-3-2-route-1",
+              "service-3-3": "service-3-3-route-1",
+              "service-3-4": "HGET",
+              "service-3-5": "service-3-5-route-1",
+              "service-3-6": "service-3-6-route-1",
+              "service-3-7": "service-3-7-route-1",
+              "service-3-8": "service-3-8-route-1",
+              "service-3-9": "service-3-9-route-1"
+            },
+            "maxLatencyMillis": 35,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-1",
+        "instances": [
+          "service-2-1-instance-0",
+          "service-2-1-instance-1",
+          "service-2-1-instance-2",
+          "service-2-1-instance-3",
+          "service-2-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 58,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-2",
+        "instances": [
+          "service-2-2-instance-0",
+          "service-2-2-instance-1",
+          "service-2-2-instance-2",
+          "service-2-2-instance-3",
+          "service-2-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 38,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-3",
+        "instances": [
+          "service-2-3-instance-0",
+          "service-2-3-instance-1",
+          "service-2-3-instance-2",
+          "service-2-3-instance-3",
+          "service-2-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 47,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-4",
+        "instances": [
+          "service-2-4-instance-0",
+          "service-2-4-instance-1",
+          "service-2-4-instance-2",
+          "service-2-4-instance-3",
+          "service-2-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 97,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-5",
+        "instances": [
+          "service-2-5-instance-0",
+          "service-2-5-instance-1",
+          "service-2-5-instance-2",
+          "service-2-5-instance-3",
+          "service-2-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "postgres.query",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 40,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "postgres",
+                  "db.system": "postgresql",
+                  "db.user": "postgres",
+                  "network.peer.address": "test-db"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-2-6",
+        "instances": [
+          "service-2-6-instance-0",
+          "service-2-6-instance-1",
+          "service-2-6-instance-2",
+          "service-2-6-instance-3",
+          "service-2-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 35,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 58,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-7",
+        "instances": [
+          "service-2-7-instance-0",
+          "service-2-7-instance-1",
+          "service-2-7-instance-2",
+          "service-2-7-instance-3",
+          "service-2-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 45,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 78,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-8",
+        "instances": [
+          "service-2-8-instance-0",
+          "service-2-8-instance-1",
+          "service-2-8-instance-2",
+          "service-2-8-instance-3",
+          "service-2-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 23,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 36,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-2-9",
+        "instances": [
+          "service-2-9-instance-0",
+          "service-2-9-instance-1",
+          "service-2-9-instance-2",
+          "service-2-9-instance-3",
+          "service-2-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-2-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 42,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-2-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 99,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-0",
+        "instances": [
+          "service-3-0-instance-0",
+          "service-3-0-instance-1",
+          "service-3-0-instance-2",
+          "service-3-0-instance-3",
+          "service-3-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-0-route-0",
+            "downstreamCalls": {
+              "service-4-0": "service-4-0-route-0",
+              "service-4-1": "postgres.query",
+              "service-4-2": "service-4-2-route-0",
+              "service-4-3": "service-4-3-route-0",
+              "service-4-4": "service-4-4-route-0",
+              "service-4-5": "service-4-5-route-0",
+              "service-4-6": "service-4-6-route-0",
+              "service-4-7": "service-4-7-route-0",
+              "service-4-8": "service-4-8-route-0",
+              "service-4-9": "service-4-9-route-0"
+            },
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-0-route-1",
+            "downstreamCalls": {
+              "service-4-0": "service-4-0-route-1",
+              "service-4-1": "postgres.query",
+              "service-4-2": "service-4-2-route-1",
+              "service-4-3": "service-4-3-route-1",
+              "service-4-4": "service-4-4-route-1",
+              "service-4-5": "service-4-5-route-1",
+              "service-4-6": "service-4-6-route-1",
+              "service-4-7": "service-4-7-route-1",
+              "service-4-8": "service-4-8-route-1",
+              "service-4-9": "service-4-9-route-1"
+            },
+            "maxLatencyMillis": 96,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-1",
+        "instances": [
+          "service-3-1-instance-0",
+          "service-3-1-instance-1",
+          "service-3-1-instance-2",
+          "service-3-1-instance-3",
+          "service-3-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 19,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 18,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-2",
+        "instances": [
+          "service-3-2-instance-0",
+          "service-3-2-instance-1",
+          "service-3-2-instance-2",
+          "service-3-2-instance-3",
+          "service-3-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 48,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-3",
+        "instances": [
+          "service-3-3-instance-0",
+          "service-3-3-instance-1",
+          "service-3-3-instance-2",
+          "service-3-3-instance-3",
+          "service-3-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 46,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-4",
+        "instances": [
+          "service-3-4-instance-0",
+          "service-3-4-instance-1",
+          "service-3-4-instance-2",
+          "service-3-4-instance-3",
+          "service-3-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "HGET",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "HGETALL",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 79,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "redis",
+                  "db.system": "redis",
+                  "db.user": "redis",
+                  "server.address": "demo-redis"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-3-5",
+        "instances": [
+          "service-3-5-instance-0",
+          "service-3-5-instance-1",
+          "service-3-5-instance-2",
+          "service-3-5-instance-3",
+          "service-3-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 70,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 61,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-6",
+        "instances": [
+          "service-3-6-instance-0",
+          "service-3-6-instance-1",
+          "service-3-6-instance-2",
+          "service-3-6-instance-3",
+          "service-3-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 13,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 23,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-7",
+        "instances": [
+          "service-3-7-instance-0",
+          "service-3-7-instance-1",
+          "service-3-7-instance-2",
+          "service-3-7-instance-3",
+          "service-3-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 13,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 68,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-8",
+        "instances": [
+          "service-3-8-instance-0",
+          "service-3-8-instance-1",
+          "service-3-8-instance-2",
+          "service-3-8-instance-3",
+          "service-3-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 67,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-3-9",
+        "instances": [
+          "service-3-9-instance-0",
+          "service-3-9-instance-1",
+          "service-3-9-instance-2",
+          "service-3-9-instance-3",
+          "service-3-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-3-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 78,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-3-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 86,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-0",
+        "instances": [
+          "service-4-0-instance-0",
+          "service-4-0-instance-1",
+          "service-4-0-instance-2",
+          "service-4-0-instance-3",
+          "service-4-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-0-route-0",
+            "downstreamCalls": {
+              "service-5-0": "service-5-0-route-0",
+              "service-5-1": "service-5-1-route-0",
+              "service-5-2": "service-5-2-route-0",
+              "service-5-3": "service-5-3-route-0",
+              "service-5-4": "service-5-4-route-0",
+              "service-5-5": "service-5-5-route-0",
+              "service-5-6": "service-5-6-route-0",
+              "service-5-7": "service-5-7-route-0",
+              "service-5-8": "service-5-8-route-0",
+              "service-5-9": "service-5-9-route-0"
+            },
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-0-route-1",
+            "downstreamCalls": {
+              "service-5-0": "service-5-0-route-1",
+              "service-5-1": "service-5-1-route-1",
+              "service-5-2": "service-5-2-route-1",
+              "service-5-3": "service-5-3-route-1",
+              "service-5-4": "service-5-4-route-1",
+              "service-5-5": "service-5-5-route-1",
+              "service-5-6": "service-5-6-route-1",
+              "service-5-7": "service-5-7-route-1",
+              "service-5-8": "service-5-8-route-1",
+              "service-5-9": "service-5-9-route-1"
+            },
+            "maxLatencyMillis": 77,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-1",
+        "instances": [
+          "service-4-1-instance-0",
+          "service-4-1-instance-1",
+          "service-4-1-instance-2",
+          "service-4-1-instance-3",
+          "service-4-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "postgres.query",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "db.name": "postgres",
+                  "db.system": "postgresql",
+                  "db.user": "postgres",
+                  "network.peer.address": "stag-db"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "db"
+      },
+      {
+        "serviceName": "service-4-2",
+        "instances": [
+          "service-4-2-instance-0",
+          "service-4-2-instance-1",
+          "service-4-2-instance-2",
+          "service-4-2-instance-3",
+          "service-4-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 29,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 56,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-3",
+        "instances": [
+          "service-4-3-instance-0",
+          "service-4-3-instance-1",
+          "service-4-3-instance-2",
+          "service-4-3-instance-3",
+          "service-4-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 94,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-4",
+        "instances": [
+          "service-4-4-instance-0",
+          "service-4-4-instance-1",
+          "service-4-4-instance-2",
+          "service-4-4-instance-3",
+          "service-4-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 47,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-5",
+        "instances": [
+          "service-4-5-instance-0",
+          "service-4-5-instance-1",
+          "service-4-5-instance-2",
+          "service-4-5-instance-3",
+          "service-4-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 82,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-6",
+        "instances": [
+          "service-4-6-instance-0",
+          "service-4-6-instance-1",
+          "service-4-6-instance-2",
+          "service-4-6-instance-3",
+          "service-4-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 41,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 33,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-7",
+        "instances": [
+          "service-4-7-instance-0",
+          "service-4-7-instance-1",
+          "service-4-7-instance-2",
+          "service-4-7-instance-3",
+          "service-4-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 46,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 83,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-8",
+        "instances": [
+          "service-4-8-instance-0",
+          "service-4-8-instance-1",
+          "service-4-8-instance-2",
+          "service-4-8-instance-3",
+          "service-4-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 27,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 69,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-4-9",
+        "instances": [
+          "service-4-9-instance-0",
+          "service-4-9-instance-1",
+          "service-4-9-instance-2",
+          "service-4-9-instance-3",
+          "service-4-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-4-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 16,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-4-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-0",
+        "instances": [
+          "service-5-0-instance-0",
+          "service-5-0-instance-1",
+          "service-5-0-instance-2",
+          "service-5-0-instance-3",
+          "service-5-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-0-route-0",
+            "downstreamCalls": {
+              "service-6-0": "service-6-0-route-0",
+              "service-6-1": "service-6-1-route-0",
+              "service-6-2": "service-6-2-route-0",
+              "service-6-3": "service-6-3-route-0",
+              "service-6-4": "service-6-4-route-0",
+              "service-6-5": "service-6-5-route-0",
+              "service-6-6": "service-6-6-route-0",
+              "service-6-7": "service-6-7-route-0",
+              "service-6-8": "service-6-8-route-0",
+              "service-6-9": "service-6-9-route-0"
+            },
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-0-route-1",
+            "downstreamCalls": {
+              "service-6-0": "service-6-0-route-1",
+              "service-6-1": "service-6-1-route-1",
+              "service-6-2": "service-6-2-route-1",
+              "service-6-3": "service-6-3-route-1",
+              "service-6-4": "service-6-4-route-1",
+              "service-6-5": "service-6-5-route-1",
+              "service-6-6": "service-6-6-route-1",
+              "service-6-7": "service-6-7-route-1",
+              "service-6-8": "service-6-8-route-1",
+              "service-6-9": "service-6-9-route-1"
+            },
+            "maxLatencyMillis": 59,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-1",
+        "instances": [
+          "service-5-1-instance-0",
+          "service-5-1-instance-1",
+          "service-5-1-instance-2",
+          "service-5-1-instance-3",
+          "service-5-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 61,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 20,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-2",
+        "instances": [
+          "service-5-2-instance-0",
+          "service-5-2-instance-1",
+          "service-5-2-instance-2",
+          "service-5-2-instance-3",
+          "service-5-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 36,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 19,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-3",
+        "instances": [
+          "service-5-3-instance-0",
+          "service-5-3-instance-1",
+          "service-5-3-instance-2",
+          "service-5-3-instance-3",
+          "service-5-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 14,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 33,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "external"
+      },
+      {
+        "serviceName": "service-5-4",
+        "instances": [
+          "service-5-4-instance-0",
+          "service-5-4-instance-1",
+          "service-5-4-instance-2",
+          "service-5-4-instance-3",
+          "service-5-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 75,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-5",
+        "instances": [
+          "service-5-5-instance-0",
+          "service-5-5-instance-1",
+          "service-5-5-instance-2",
+          "service-5-5-instance-3",
+          "service-5-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 58,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 28,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-6",
+        "instances": [
+          "service-5-6-instance-0",
+          "service-5-6-instance-1",
+          "service-5-6-instance-2",
+          "service-5-6-instance-3",
+          "service-5-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-7",
+        "instances": [
+          "service-5-7-instance-0",
+          "service-5-7-instance-1",
+          "service-5-7-instance-2",
+          "service-5-7-instance-3",
+          "service-5-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 36,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 28,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-8",
+        "instances": [
+          "service-5-8-instance-0",
+          "service-5-8-instance-1",
+          "service-5-8-instance-2",
+          "service-5-8-instance-3",
+          "service-5-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 97,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 99,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-5-9",
+        "instances": [
+          "service-5-9-instance-0",
+          "service-5-9-instance-1",
+          "service-5-9-instance-2",
+          "service-5-9-instance-3",
+          "service-5-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-5-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 55,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-5-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 40,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-west3-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-west3"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-0",
+        "instances": [
+          "service-6-0-instance-0",
+          "service-6-0-instance-1",
+          "service-6-0-instance-2",
+          "service-6-0-instance-3",
+          "service-6-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-0-route-0",
+            "downstreamCalls": {
+              "service-7-0": "service-7-0-route-0",
+              "service-7-1": "service-7-1-route-0",
+              "service-7-2": "service-7-2-route-0",
+              "service-7-3": "service-7-3-route-0",
+              "service-7-4": "service-7-4-route-0",
+              "service-7-5": "service-7-5-route-0",
+              "service-7-6": "service-7-6-route-0",
+              "service-7-7": "service-7-7-route-0",
+              "service-7-8": "service-7-8-route-0",
+              "service-7-9": "service-7-9-route-0"
+            },
+            "maxLatencyMillis": 45,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-0-route-1",
+            "downstreamCalls": {
+              "service-7-0": "service-7-0-route-1",
+              "service-7-1": "service-7-1-route-1",
+              "service-7-2": "service-7-2-route-1",
+              "service-7-3": "service-7-3-route-1",
+              "service-7-4": "service-7-4-route-1",
+              "service-7-5": "service-7-5-route-1",
+              "service-7-6": "service-7-6-route-1",
+              "service-7-7": "service-7-7-route-1",
+              "service-7-8": "service-7-8-route-1",
+              "service-7-9": "service-7-9-route-1"
+            },
+            "maxLatencyMillis": 17,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-1",
+        "instances": [
+          "service-6-1-instance-0",
+          "service-6-1-instance-1",
+          "service-6-1-instance-2",
+          "service-6-1-instance-3",
+          "service-6-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 32,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 65,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-2",
+        "instances": [
+          "service-6-2-instance-0",
+          "service-6-2-instance-1",
+          "service-6-2-instance-2",
+          "service-6-2-instance-3",
+          "service-6-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 95,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 98,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-3",
+        "instances": [
+          "service-6-3-instance-0",
+          "service-6-3-instance-1",
+          "service-6-3-instance-2",
+          "service-6-3-instance-3",
+          "service-6-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 47,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-4",
+        "instances": [
+          "service-6-4-instance-0",
+          "service-6-4-instance-1",
+          "service-6-4-instance-2",
+          "service-6-4-instance-3",
+          "service-6-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 53,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-5",
+        "instances": [
+          "service-6-5-instance-0",
+          "service-6-5-instance-1",
+          "service-6-5-instance-2",
+          "service-6-5-instance-3",
+          "service-6-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 67,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 78,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-6",
+        "instances": [
+          "service-6-6-instance-0",
+          "service-6-6-instance-1",
+          "service-6-6-instance-2",
+          "service-6-6-instance-3",
+          "service-6-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 66,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-7",
+        "instances": [
+          "service-6-7-instance-0",
+          "service-6-7-instance-1",
+          "service-6-7-instance-2",
+          "service-6-7-instance-3",
+          "service-6-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 29,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 18,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-8",
+        "instances": [
+          "service-6-8-instance-0",
+          "service-6-8-instance-1",
+          "service-6-8-instance-2",
+          "service-6-8-instance-3",
+          "service-6-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 52,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-6-9",
+        "instances": [
+          "service-6-9-instance-0",
+          "service-6-9-instance-1",
+          "service-6-9-instance-2",
+          "service-6-9-instance-3",
+          "service-6-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-6-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 63,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-6-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 49,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-0",
+        "instances": [
+          "service-7-0-instance-0",
+          "service-7-0-instance-1",
+          "service-7-0-instance-2",
+          "service-7-0-instance-3",
+          "service-7-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-0-route-0",
+            "downstreamCalls": {
+              "service-8-0": "service-8-0-route-0",
+              "service-8-1": "service-8-1-route-0",
+              "service-8-2": "service-8-2-route-0",
+              "service-8-3": "service-8-3-route-0",
+              "service-8-4": "service-8-4-route-0",
+              "service-8-5": "service-8-5-route-0",
+              "service-8-6": "service-8-6-route-0",
+              "service-8-7": "service-8-7-route-0",
+              "service-8-8": "service-8-8-route-0",
+              "service-8-9": "service-8-9-route-0"
+            },
+            "maxLatencyMillis": 37,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-0-route-1",
+            "downstreamCalls": {
+              "service-8-0": "service-8-0-route-1",
+              "service-8-1": "service-8-1-route-1",
+              "service-8-2": "service-8-2-route-1",
+              "service-8-3": "service-8-3-route-1",
+              "service-8-4": "service-8-4-route-1",
+              "service-8-5": "service-8-5-route-1",
+              "service-8-6": "service-8-6-route-1",
+              "service-8-7": "service-8-7-route-1",
+              "service-8-8": "service-8-8-route-1",
+              "service-8-9": "service-8-9-route-1"
+            },
+            "maxLatencyMillis": 91,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-1",
+        "instances": [
+          "service-7-1-instance-0",
+          "service-7-1-instance-1",
+          "service-7-1-instance-2",
+          "service-7-1-instance-3",
+          "service-7-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 86,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 39,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-2",
+        "instances": [
+          "service-7-2-instance-0",
+          "service-7-2-instance-1",
+          "service-7-2-instance-2",
+          "service-7-2-instance-3",
+          "service-7-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 79,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 96,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag",
+                  "subtype": "external.dns.com",
+                  "peer.service": "external.dns.com"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "external"
+      },
+      {
+        "serviceName": "service-7-3",
+        "instances": [
+          "service-7-3-instance-0",
+          "service-7-3-instance-1",
+          "service-7-3-instance-2",
+          "service-7-3-instance-3",
+          "service-7-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 35,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 59,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-4",
+        "instances": [
+          "service-7-4-instance-0",
+          "service-7-4-instance-1",
+          "service-7-4-instance-2",
+          "service-7-4-instance-3",
+          "service-7-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 14,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 11,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-5",
+        "instances": [
+          "service-7-5-instance-0",
+          "service-7-5-instance-1",
+          "service-7-5-instance-2",
+          "service-7-5-instance-3",
+          "service-7-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 73,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 43,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-6",
+        "instances": [
+          "service-7-6-instance-0",
+          "service-7-6-instance-1",
+          "service-7-6-instance-2",
+          "service-7-6-instance-3",
+          "service-7-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 55,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 85,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-7",
+        "instances": [
+          "service-7-7-instance-0",
+          "service-7-7-instance-1",
+          "service-7-7-instance-2",
+          "service-7-7-instance-3",
+          "service-7-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 13,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 89,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-8",
+        "instances": [
+          "service-7-8-instance-0",
+          "service-7-8-instance-1",
+          "service-7-8-instance-2",
+          "service-7-8-instance-3",
+          "service-7-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 76,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-7-9",
+        "instances": [
+          "service-7-9-instance-0",
+          "service-7-9-instance-1",
+          "service-7-9-instance-2",
+          "service-7-9-instance-3",
+          "service-7-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-7-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 84,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-7-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 44,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "docker",
+          "availability_zone": "us-south1-a",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-south1"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-8-0",
+        "instances": [
+          "service-8-0-instance-0",
+          "service-8-0-instance-1",
+          "service-8-0-instance-2",
+          "service-8-0-instance-3",
+          "service-8-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-0-route-0",
+            "downstreamCalls": {
+              "service-9-0": "service-9-0-route-0",
+              "service-9-1": "service-9-1-route-0",
+              "service-9-2": "service-9-2-route-0",
+              "service-9-3": "service-9-3-route-0",
+              "service-9-4": "service-9-4-route-0",
+              "service-9-5": "service-9-5-route-0",
+              "service-9-6": "service-9-6-route-0",
+              "service-9-7": "service-9-7-route-0",
+              "service-9-8": "service-9-8-route-0",
+              "service-9-9": "service-9-9-route-0"
+            },
+            "maxLatencyMillis": 54,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-0-route-1",
+            "downstreamCalls": {
+              "service-9-0": "service-9-0-route-1",
+              "service-9-1": "service-9-1-route-1",
+              "service-9-2": "service-9-2-route-1",
+              "service-9-3": "service-9-3-route-1",
+              "service-9-4": "service-9-4-route-1",
+              "service-9-5": "service-9-5-route-1",
+              "service-9-6": "service-9-6-route-1",
+              "service-9-7": "service-9-7-route-1",
+              "service-9-8": "service-9-8-route-1",
+              "service-9-9": "service-9-9-route-1"
+            },
+            "maxLatencyMillis": 42,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-1",
+        "instances": [
+          "service-8-1-instance-0",
+          "service-8-1-instance-1",
+          "service-8-1-instance-2",
+          "service-8-1-instance-3",
+          "service-8-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 10,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 93,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-2",
+        "instances": [
+          "service-8-2-instance-0",
+          "service-8-2-instance-1",
+          "service-8-2-instance-2",
+          "service-8-2-instance-3",
+          "service-8-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 30,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-3",
+        "instances": [
+          "service-8-3-instance-0",
+          "service-8-3-instance-1",
+          "service-8-3-instance-2",
+          "service-8-3-instance-3",
+          "service-8-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 67,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 18,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-4",
+        "instances": [
+          "service-8-4-instance-0",
+          "service-8-4-instance-1",
+          "service-8-4-instance-2",
+          "service-8-4-instance-3",
+          "service-8-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 56,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-5",
+        "instances": [
+          "service-8-5-instance-0",
+          "service-8-5-instance-1",
+          "service-8-5-instance-2",
+          "service-8-5-instance-3",
+          "service-8-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 86,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 83,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-6",
+        "instances": [
+          "service-8-6-instance-0",
+          "service-8-6-instance-1",
+          "service-8-6-instance-2",
+          "service-8-6-instance-3",
+          "service-8-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 57,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 27,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-7",
+        "instances": [
+          "service-8-7-instance-0",
+          "service-8-7-instance-1",
+          "service-8-7-instance-2",
+          "service-8-7-instance-3",
+          "service-8-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 85,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 24,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-8",
+        "instances": [
+          "service-8-8-instance-0",
+          "service-8-8-instance-1",
+          "service-8-8-instance-2",
+          "service-8-8-instance-3",
+          "service-8-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 64,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-8-9",
+        "instances": [
+          "service-8-9-instance-0",
+          "service-8-9-instance-1",
+          "service-8-9-instance-2",
+          "service-8-9-instance-3",
+          "service-8-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-8-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-8-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 27,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceType": "http",
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-central1-c",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "dev-aws",
+          "kube_namespace": "load-trace",
+          "region": "us-central1"
+        }
+      },
+      {
+        "serviceName": "service-9-0",
+        "instances": [
+          "service-9-0-instance-0",
+          "service-9-0-instance-1",
+          "service-9-0-instance-2",
+          "service-9-0-instance-3",
+          "service-9-0-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-0-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 71,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-0-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-1",
+        "instances": [
+          "service-9-1-instance-0",
+          "service-9-1-instance-1",
+          "service-9-1-instance-2",
+          "service-9-1-instance-3",
+          "service-9-1-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-1-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 74,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-1-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 92,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-2",
+        "instances": [
+          "service-9-2-instance-0",
+          "service-9-2-instance-1",
+          "service-9-2-instance-2",
+          "service-9-2-instance-3",
+          "service-9-2-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-2-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 26,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-2-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 33,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-3",
+        "instances": [
+          "service-9-3-instance-0",
+          "service-9-3-instance-1",
+          "service-9-3-instance-2",
+          "service-9-3-instance-3",
+          "service-9-3-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-3-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 53,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-3-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 81,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-4",
+        "instances": [
+          "service-9-4-instance-0",
+          "service-9-4-instance-1",
+          "service-9-4-instance-2",
+          "service-9-4-instance-3",
+          "service-9-4-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-4-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 83,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-4-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 28,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-5",
+        "instances": [
+          "service-9-5-instance-0",
+          "service-9-5-instance-1",
+          "service-9-5-instance-2",
+          "service-9-5-instance-3",
+          "service-9-5-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-5-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 53,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-5-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 89,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-6",
+        "instances": [
+          "service-9-6-instance-0",
+          "service-9-6-instance-1",
+          "service-9-6-instance-2",
+          "service-9-6-instance-3",
+          "service-9-6-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-6-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 52,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-6-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-7",
+        "instances": [
+          "service-9-7-instance-0",
+          "service-9-7-instance-1",
+          "service-9-7-instance-2",
+          "service-9-7-instance-3",
+          "service-9-7-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-7-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 80,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-7-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 12,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-8",
+        "instances": [
+          "service-9-8-instance-0",
+          "service-9-8-instance-1",
+          "service-9-8-instance-2",
+          "service-9-8-instance-3",
+          "service-9-8-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-8-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 97,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-8-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 48,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      },
+      {
+        "serviceName": "service-9-9",
+        "instances": [
+          "service-9-9-instance-0",
+          "service-9-9-instance-1",
+          "service-9-9-instance-2",
+          "service-9-9-instance-3",
+          "service-9-9-instance-4"
+        ],
+        "routes": [
+          {
+            "route": "service-9-9-route-0",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 90,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "route": "service-9-9-route-1",
+            "downstreamCalls": {},
+            "maxLatencyMillis": 93,
+            "tagSets": [
+              {
+                "tags": {
+                  "version": "version-1",
+                  "env": "stag"
+                },
+                "tagGenerators": [
+                  {
+                    "numTags": 4,
+                    "numVals": 5,
+                    "valLength": 8
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "serviceLabels": {
+          "kf_platform": "kubernetes",
+          "availability_zone": "us-east4-b",
+          "cloud_account_id": "mvp-demo",
+          "kube_cluster_name": "aws-shared",
+          "kube_namespace": "omni-trace",
+          "region": "us-east4"
+        },
+        "serviceType": "http"
+      }
+    ]
+  },
+  "rootRoutes": [
+    {
+      "service": "service-0",
+      "route": "route-0",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-1",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-2",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-3",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-4",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-5",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-6",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-7",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-8",
+      "tracesPerHour": 350000
+    },
+    {
+      "service": "service-0",
+      "route": "route-9",
+      "tracesPerHour": 3600
+    }
+  ]
+}


### PR DESCRIPTION
Added support for the following to the synthetic generator: 

1. Longer spans which can be controlled through `minLatencyMillis`
2. Fixed span timings to ensure emitted traces don't have spans in the future. 
3. Added support for service labels. 
4. Added DB and External type services. 

[#748](https://github.com/kloudfuse/bugzilla/issues/748)